### PR TITLE
confd: Fix backslashes being removed from envvars

### DIFF
--- a/src/entry.sh
+++ b/src/entry.sh
@@ -9,5 +9,7 @@ echo -e "${GREEN}Systemd init system enabled."
 # We need this sleep to ensure this doesn't occur, else
 # logging to the console will not work.
 sleep infinity &
-env > /etc/docker.env
+for var in $(compgen -e); do
+	printf '%q=%q\n' "$var" "${!var}"
+done > /etc/docker.env
 exec /sbin/init


### PR DESCRIPTION
We were using `env > /etc/docker.env` for storing a container's
environment to an envfile, to be used as `EnvironmentFile` for
`confd.service`. This way, backslash characters were "consumed" as
described [here](https://www.freedesktop.org/software/systemd/man/systemd.exec.html#EnvironmentFile=)

Change-type: patch
Signed-off-by: Michael Angelos Simos <michalis@balena.io>
Connects to #66 