### PR TITLE
mdns: Ensure multi-part subdomains are allowed

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -90,6 +90,7 @@ COPY src/rsyslog.conf src/nsswitch.conf /etc/
 COPY src/dbus-no-oom-adjust.conf /etc/systemd/system/dbus.service.d/
 COPY src/entry.sh /usr/bin/
 COPY src/htoprc /root/.config/htop/
+COPY src/mdns.allow /etc/mdns.allow
 
 VOLUME ["/sys/fs/cgroup"]
 VOLUME ["/run"]

--- a/src/mdns.allow
+++ b/src/mdns.allow
@@ -1,0 +1,2 @@
+.local.
+.local


### PR DESCRIPTION
Debian Buster now uses Avahi 0.7 instead of
0.6.32. This means that there is now a stricter
policy defining MDNS domains. This commit allows
us to use multipart subdomains.

Change-type: patch
Signed-off-by: Heds Simons <heds@balena.io>