### PR TITLE
Add a base image without systemd

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,26 @@
+---
+version: 2
+jobs:
+  build:
+    machine:
+      image: ubuntu-1604:201903-01
+    working_directory: /tmp/build
+    environment:
+      DOCKER_USERNAME: travisciresin
+      DOCKER_IMAGE: balena/open-balena-base
+    steps:
+      - checkout
+      - run:
+          name: Build
+          command: |
+            dockerBranchTag=${CIRCLE_BRANCH//[^a-zA-Z0-9_-]/-}
+            docker login -u="$DOCKER_USERNAME" -p="$DOCKER_PASSWORD"
+            docker pull ${DOCKER_IMAGE}:no-systemd-${dockerBranchTag} || docker pull ${DOCKER_IMAGE}:no-systemd-master || true
+            docker build -f Dockerfile.no-systemd -t ${DOCKER_IMAGE}:no-systemd-${CIRCLE_SHA1} .
+      - run:
+          name: Publish
+          command: |
+            dockerBranchTag=${CIRCLE_BRANCH//[^a-zA-Z0-9_-]/-}
+            docker push ${DOCKER_IMAGE}:no-systemd-${CIRCLE_SHA1}
+            docker tag ${DOCKER_IMAGE}:no-systemd-${CIRCLE_SHA1} ${DOCKER_IMAGE}:${dockerBranchTag}
+            docker push ${DOCKER_IMAGE}:${dockerBranchTag}

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -22,5 +22,5 @@ jobs:
           command: |
             dockerBranchTag=${CIRCLE_BRANCH//[^a-zA-Z0-9_-]/-}
             docker push ${DOCKER_IMAGE}:no-systemd-${CIRCLE_SHA1}
-            docker tag ${DOCKER_IMAGE}:no-systemd-${CIRCLE_SHA1} ${DOCKER_IMAGE}:${dockerBranchTag}
-            docker push ${DOCKER_IMAGE}:${dockerBranchTag}
+            docker tag ${DOCKER_IMAGE}:no-systemd-${CIRCLE_SHA1} ${DOCKER_IMAGE}:no-systemd-${dockerBranchTag}
+            docker push ${DOCKER_IMAGE}:no-systemd-${dockerBranchTag}

--- a/Dockerfile.no-systemd
+++ b/Dockerfile.no-systemd
@@ -1,0 +1,36 @@
+FROM balenalib/amd64-debian:buster-run
+
+ENV TERM xterm
+
+# Install ops/sre related packages.
+RUN install_packages \
+		htop \
+		jq \
+		nano \
+		netcat \
+		net-tools \
+		ifupdown \
+		strace \
+		vim \
+		wget
+# And configure them.
+COPY src/htoprc /root/.config/htop/
+
+# We use NodeJs everywhere.
+ENV NODE_VERSION 10.16.3
+ENV NPM_VERSION 6.10.3
+RUN curl -SL "https://nodejs.org/dist/v$NODE_VERSION/node-v$NODE_VERSION-linux-x64.tar.gz" | tar xz -C /usr/local --strip-components=1 \
+	&& npm install -g npm@"$NPM_VERSION" \
+	&& npm cache clear --force \
+	&& rm -rf /tmp/*
+
+# Confd binary will be removed once we migrate to a different configuration management.
+ENV CONFD_VERSION 0.16.0
+RUN wget -O /usr/local/bin/confd https://github.com/kelseyhightower/confd/releases/download/v${CONFD_VERSION}/confd-${CONFD_VERSION}-linux-amd64 \
+	&& chmod a+x /usr/local/bin/confd
+ONBUILD COPY config/confd /etc/confd
+RUN mkdir /balena
+
+# Set an entry point that runs confd if necessary before executing the main process.
+COPY src/confd-entry.sh /usr/bin/confd-entry.sh
+ENTRYPOINT ["/usr/bin/confd-entry.sh"]

--- a/Dockerfile.no-systemd
+++ b/Dockerfile.no-systemd
@@ -16,13 +16,19 @@ RUN install_packages \
 # And configure them.
 COPY src/htoprc /root/.config/htop/
 
-# Confd binary will be removed once we migrate to a different configuration management.
-ENV CONFD_VERSION 0.16.0
-RUN wget -O /usr/local/bin/confd https://github.com/kelseyhightower/confd/releases/download/v${CONFD_VERSION}/confd-${CONFD_VERSION}-linux-amd64 \
-	&& chmod a+x /usr/local/bin/confd
-ONBUILD COPY config/confd /etc/confd
+# === Confd part ===
+# May be removed once we switch to a different configuration mechanism.
+
+# Directory where rendered environment files are store.
 RUN mkdir /balena
 
 # Set an entry point that runs confd if necessary before executing the main process.
-COPY src/confd-entry.sh /usr/bin/confd-entry.sh
 ENTRYPOINT ["/usr/bin/confd-entry.sh"]
+COPY src/confd-entry.sh /usr/bin/confd-entry.sh
+
+ONBUILD COPY config/confd /etc/confd
+
+# Confd binary installation.
+ENV CONFD_VERSION 0.16.0
+RUN wget -O /usr/local/bin/confd https://github.com/kelseyhightower/confd/releases/download/v${CONFD_VERSION}/confd-${CONFD_VERSION}-linux-amd64 \
+	&& chmod a+x /usr/local/bin/confd

--- a/Dockerfile.no-systemd
+++ b/Dockerfile.no-systemd
@@ -1,4 +1,4 @@
-FROM balenalib/amd64-debian:buster-run
+FROM balenalib/amd64-debian-node:10.16.3-buster-run
 
 ENV TERM xterm
 
@@ -15,14 +15,6 @@ RUN install_packages \
 		wget
 # And configure them.
 COPY src/htoprc /root/.config/htop/
-
-# We use NodeJs everywhere.
-ENV NODE_VERSION 10.16.3
-ENV NPM_VERSION 6.10.3
-RUN curl -SL "https://nodejs.org/dist/v$NODE_VERSION/node-v$NODE_VERSION-linux-x64.tar.gz" | tar xz -C /usr/local --strip-components=1 \
-	&& npm install -g npm@"$NPM_VERSION" \
-	&& npm cache clear --force \
-	&& rm -rf /tmp/*
 
 # Confd binary will be removed once we migrate to a different configuration management.
 ENV CONFD_VERSION 0.16.0

--- a/Dockerfile.no-systemd
+++ b/Dockerfile.no-systemd
@@ -28,6 +28,9 @@ COPY src/confd-entry.sh /usr/bin/confd-entry.sh
 
 ONBUILD COPY config/confd /etc/confd
 
+# Script that derives typical environment variables from BALENA_TLD.
+COPY src/configure-balena-host-envvars.sh /usr/bin/configure-balena-host-envvars.sh
+
 # Confd binary installation.
 ENV CONFD_VERSION 0.16.0
 RUN wget -O /usr/local/bin/confd https://github.com/kelseyhightower/confd/releases/download/v${CONFD_VERSION}/confd-${CONFD_VERSION}-linux-amd64 \

--- a/src/confd-entry.sh
+++ b/src/confd-entry.sh
@@ -10,4 +10,12 @@ if [[ "$BALENA_USE_CONFD" = "1" ]]; then
   set +a
 fi
 
+# Set some typical missing env variables (like BALENA_API_HOST) deriving them from BALENA_TLD.
+# Used in BoB.
+/usr/bin/configure-balena-host-envvars.sh
+set -a
+# It's an optional step, ok to fail.
+source /etc/docker.env 2>/dev/null && echo "info: Missing typical variables are set using BALENA_TLD"
+set +a
+
 exec $@

--- a/src/confd-entry.sh
+++ b/src/confd-entry.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+
+if [[ "$BALENA_USE_CONFD" = "1" ]]; then
+  # When this environment variable is set, we need to pull configuration from etcd.
+  # The image is expected to have an environment file template located in /etc/confd,
+  # and this template should be configured to rencer the actual file to /balena/env.
+  /usr/local/bin/confd -onetime -node http://172.17.42.1:4001 || exit 1
+  set -a
+  source /balena/env || exit 1
+  set +a
+fi
+
+exec $@

--- a/src/configure-balena-host-envvars.sh
+++ b/src/configure-balena-host-envvars.sh
@@ -36,23 +36,25 @@ HOST_ENVVARS[BALENA_SENTRY_URL_HOST]=sentry
 HOST_ENVVARS[BALENA_MONITOR_HOST]=monitor
 
 # Go through the lists and fill in any missing envvars
-for VARNAME in "${!HOST_ENVVARS[@]}"; do
-    VARVALUE=${!VARNAME}
-    if [[ -z "$VARVALUE" ]]; then
-        PREFIX="${HOST_ENVVARS[$VARNAME]}"
-        # Only use BALENA_DEVICE_UUID if it actually exists, else just use the
-        # full passed in TLD
-        DEVICE=""
-        if [[ ! -z "$BALENA_DEVICE_UUID" ]]; then
-            DEVICE="$BALENA_DEVICE_UUID."
-        fi
-        SUBDOMAIN="$PREFIX.$DEVICE$BALENA_TLD"
+if [[ -n "$BALENA_TLD" ]]; then
+  for VARNAME in "${!HOST_ENVVARS[@]}"; do
+      VARVALUE=${!VARNAME}
+      if [[ -z "$VARVALUE" ]]; then
+          PREFIX="${HOST_ENVVARS[$VARNAME]}"
+          # Only use BALENA_DEVICE_UUID if it actually exists, else just use the
+          # full passed in TLD
+          DEVICE=""
+          if [[ ! -z "$BALENA_DEVICE_UUID" ]]; then
+              DEVICE="$BALENA_DEVICE_UUID."
+          fi
+          SUBDOMAIN="$PREFIX.$DEVICE$BALENA_TLD"
 
-        # Several vars require special formatting
-        if [ "$VARNAME" == "BALENA_TOKEN_AUTH_REALM" ]; then
-            SUBDOMAIN="https://$SUBDOMAIN/auth/v1/token"
-        fi
+          # Several vars require special formatting
+          if [ "$VARNAME" == "BALENA_TOKEN_AUTH_REALM" ]; then
+              SUBDOMAIN="https://$SUBDOMAIN/auth/v1/token"
+          fi
 
-        echo "$VARNAME=$SUBDOMAIN" >> /etc/docker.env
-    fi
-done
+          echo "$VARNAME=$SUBDOMAIN" >> /etc/docker.env
+      fi
+  done
+fi


### PR DESCRIPTION
Also configures balenaCI to publish no-systemd variant in parallel.

Based on balena base image.

This image has `confd` included and runs it once on container start if requested with a special env variable.
It basically means you can run our service with with 
```
docker run -e BALENA_USE_CONFD=1 balena/balena-service
```
and it will pull configuration from `etcd`, or you can set environment variables directly.

Service images are supposed to set `CMD` on their images that will be used as the main process.

According to arch calls: https://app.frontapp.com/open/cnv_30v6r43 and https://app.frontapp.com/open/cnv_2s8cuir

Change-type: minor
Signed-off-by: Roman Mazur <roman@balena.io>