### PR TITLE
Don't use UID used in node archive when unpacking as root

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -46,7 +46,7 @@ RUN apt-get update \
 ENV NODE_VERSION 12.13.0
 ENV NPM_VERSION 6.12.0
 
-RUN curl -SL "https://nodejs.org/dist/v$NODE_VERSION/node-v$NODE_VERSION-linux-x64.tar.gz" | tar xz -C /usr/local --strip-components=1 \
+RUN curl -SL "https://nodejs.org/dist/v$NODE_VERSION/node-v$NODE_VERSION-linux-x64.tar.gz" | tar xz -C /usr/local --strip-components=1 --no-same-owner \
 	&& npm install -g npm@"$NPM_VERSION" \
 	&& npm cache clear --force \
 	&& rm -rf /tmp/*


### PR DESCRIPTION
First symptom was running this
```bash
docker run --rm -it balena/open-balena-base:v9.0.1 npm install balena-cli -g --unsafe-perm --production
```
It fails with a bunch of warnings such as 
```
npm WARN tar ENOENT: no such file or directory, lstat '/usr/local/lib/node_modules/.staging/etcher-sdk-76dfc09d/build/source-destination'
```
and an error
```
npm ERR! fatal: could not create leading directories of '/root/.npm/_cacache/tmp/git-clone-b46ed212': Permission denied
```

Root cause is node tar archive: files are stored with UID 1001, which is preserved when unpacking as root. Node tar archive has to be unpacked with option `--no-same-owner` which will change UID to that of the current user (root). The option is also used by [upstream node image](https://github.com/nodejs/docker-node/blob/master/12/stretch/Dockerfile#L41)


Change-type: patch
Signed-off-by: Federico Fissore <federico@balena.io>