### PR TITLE
Remove cgroup volume since it makes systemd unable to start

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -93,7 +93,7 @@ COPY src/entry.sh /usr/bin/
 COPY src/htoprc /root/.config/htop/
 COPY src/mdns.allow /etc/mdns.allow
 
-VOLUME ["/sys/fs/cgroup"]
+#VOLUME ["/sys/fs/cgroup"]
 VOLUME ["/run"]
 VOLUME ["/run/lock"]
 


### PR DESCRIPTION
We had the same issue in the base images before, from systemd v230 onwards, no need to mount cgroup, otherwise systemd will not be able to start.

Change-type: patch
Signed-off-by: Trong Nghia Nguyen <nghiant2710@gmail.com>